### PR TITLE
Changes pip and apt-get install to support word-list requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ LABEL org.label-schema.vcs-url="https://github.com/lirantal/docker-detect-secret
 LABEL org.label-schema.build-date=$BUILD_DATE
 LABEL org.label-schema.docker.cmd="docker run -it --rm --name detect-secrets --volume `pwd`:/usr/src/app lirantal/detect-secrets 'src/component.js'"
 
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
-RUN pip install detect-secrets
+RUN apt-get update && apt-get install -y --no-install-recommends git build-essential && rm -rf /var/lib/apt/lists/*
+RUN pip install detect-secrets[word_list]
 
 WORKDIR /usr/src/app
 ENTRYPOINT ["detect-secrets-hook", "--verbose"]


### PR DESCRIPTION
Changes `pip install detect-secrets` to `pip install detect-secrets[word_list]` to install `pyahocorasick` allowing the use of `--word-list` flag, according to [Yelp's detect-secrets documentation](https://github.com/Yelp/detect-secrets#extensions).

As `pyahocorasick` is implemented in C, it also adds `build-essential` installation via apt-get.